### PR TITLE
Executables exit with script's exit code on failure

### DIFF
--- a/message-db.gemspec
+++ b/message-db.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
 
   s.files = Dir.glob('{database}/**/*')
+  s.files << 'script_init.rb'
   s.executables = Dir.glob('scripts/mdb-*').map(&File.method(:basename))
   s.bindir = 'scripts'
 end

--- a/script_init.rb
+++ b/script_init.rb
@@ -1,0 +1,11 @@
+def run_database_script(script_filename)
+  root = File.expand_path 'database', __dir__
+  script_filepath = File.join root, script_filename
+
+  success = system(script_filepath)
+
+  if not success
+    exit_status = $?.exitstatus
+    exit exit_status
+  end
+end

--- a/scripts/mdb-clear-messages
+++ b/scripts/mdb-clear-messages
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'clear-messages.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'clear-messages.sh'

--- a/scripts/mdb-create-db
+++ b/scripts/mdb-create-db
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'install.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'install.sh'

--- a/scripts/mdb-delete-db
+++ b/scripts/mdb-delete-db
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'uninstall.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'uninstall.sh'

--- a/scripts/mdb-install-functions
+++ b/scripts/mdb-install-functions
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'install-functions.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'install-functions.sh'

--- a/scripts/mdb-install-indexes
+++ b/scripts/mdb-install-indexes
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'install-indexes.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'install-indexes.sh'

--- a/scripts/mdb-install-privileges
+++ b/scripts/mdb-install-privileges
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'install-privileges.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'install-privileges.sh'

--- a/scripts/mdb-install-views
+++ b/scripts/mdb-install-views
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'install-views.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'install-views.sh'

--- a/scripts/mdb-print-category-type-summary
+++ b/scripts/mdb-print-category-type-summary
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'print-category-type-summary.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'print-category-type-summary.sh'

--- a/scripts/mdb-print-message-store-version
+++ b/scripts/mdb-print-message-store-version
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'print-message-store-version.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'print-message-store-version.sh'

--- a/scripts/mdb-print-messages
+++ b/scripts/mdb-print-messages
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'print-messages.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'print-messages.sh'

--- a/scripts/mdb-print-stream-summary
+++ b/scripts/mdb-print-stream-summary
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'print-stream-summary.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'print-stream-summary.sh'

--- a/scripts/mdb-print-stream-type-summary
+++ b/scripts/mdb-print-stream-type-summary
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'print-stream-type-summary.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'print-stream-type-summary.sh'

--- a/scripts/mdb-print-type-category-summary
+++ b/scripts/mdb-print-type-category-summary
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'print-type-category-summary.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'print-type-category-summary.sh'

--- a/scripts/mdb-print-type-stream-summary
+++ b/scripts/mdb-print-type-stream-summary
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'print-type-stream-summary.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'print-type-stream-summary.sh'

--- a/scripts/mdb-print-type-summary
+++ b/scripts/mdb-print-type-summary
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'print-type-summary.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'print-type-summary.sh'

--- a/scripts/mdb-recreate-db
+++ b/scripts/mdb-recreate-db
@@ -1,11 +1,7 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
+require_relative '../script_init'
 
-script_filename = 'uninstall.sh'
-script_filepath = File.join root, script_filename
-system script_filepath
+run_database_script 'uninstall.sh'
 
-script_filename = 'install.sh'
-script_filepath = File.join root, script_filename
-system script_filepath
+run_database_script 'install.sh'

--- a/scripts/mdb-write-test-message
+++ b/scripts/mdb-write-test-message
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-root = File.expand_path '../database', __dir__
-script_filename = 'write-test-message.sh'
-script_filepath = File.join root, script_filename
+require_relative '../script_init'
 
-system script_filepath
+run_database_script 'clear-messages.sh'


### PR DESCRIPTION
Addresses a concern mentioned in the Eventide slack when using any of these in scripts, this will cause them to exit with a failure code, rather than a success code when the underlying MessageDB script fails.